### PR TITLE
Add optional define for having the capsuile pointer on the heap.

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -12,7 +12,10 @@ After installing PyAwaitable, you need to initialize the ABI. This is done with 
     assert(awaitable_abi != NULL);
     ```
 
-Note that the ABI is initialized *per file*, so you need to call `awaitable_init` at least once per file. If you call `awaitable_init` after the ABI is initialized, it does nothing.
+Note that the ABI is initialized *per file* by default, so you need to call `awaitable_init` at least once per file. If you do not want to call `awaitable_init`
+outside of the module init function source file (say you separate the module init stuff from all the other module code like type objects, user defined module functions, etc.) then define
+`AWAITABLE_ABI_EXTERN` before the `#include <awaitable.h>` line in each source file.
+This will then store the capsule pointer on the heap so then it can be accessed in every source file at once. If you call `awaitable_init` after the ABI is initialized, it does nothing.
 
 For example, the ABI can be initialized in a `PyInit_*` function:
 

--- a/include/awaitable.h
+++ b/include/awaitable.h
@@ -26,7 +26,11 @@ typedef struct _awaitable_abi {
   PyTypeObject *AwaitableType;
 } AwaitableABI;
 
+#ifndef AWAITABLE_ABI_EXTERN
 static AwaitableABI *awaitable_abi = NULL;
+#else
+extern AwaitableABI *awaitable_abi = NULL;
+#endif
 
 // PyObject *awaitable_new(void);
 #define awaitable_new awaitable_abi->awaitable_new


### PR DESCRIPTION
This is for multiple c source file c extensions where the code that uses the capsule pointer is in a separate source file than the module init function, and the module init function being the only place where the capsule init is ran inside of.

Originally I was going to have a define check that the user can define their own variable for all the defines to use below, but thought against it as the change is bigger than simply doing this instead. Also with it being an optional define it should be fine.

I normally do this so I can consolidate features, and functions in my C extensions to separate source files (including type objects) so that way I can maintain them easier and faster).