### PR TITLE
Update docs.

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -15,7 +15,7 @@ After installing PyAwaitable, you need to initialize the ABI. This is done with 
 Note that the ABI is initialized *per file* by default, so you need to call `awaitable_init` at least once per file. If you do not want to call `awaitable_init`
 outside of the module init function source file (say you separate the module init stuff from all the other module code like type objects, user defined module functions, etc.) then define
 `AWAITABLE_ABI_EXTERN` before the `#include <awaitable.h>` line in each source file.
-This will then store the capsule pointer on the heap so then it can be accessed in every source file at once. If you call `awaitable_init` after the ABI is initialized, it does nothing.
+This will then store the capsule pointer as a global on the module so then it can be accessed in every source file at once. If you call `awaitable_init` after the ABI is initialized, it does nothing.
 
 For example, the ABI can be initialized in a `PyInit_*` function:
 


### PR DESCRIPTION
I said that the capsule pointer would be stored on the heap originally when this is not the case. Instead it is a global with the optional define.