### PR TITLE
Fixes to the ABI.

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -14,7 +14,7 @@ After installing PyAwaitable, you need to initialize the ABI. This is done with 
 
 Note that the ABI is initialized *per file* by default, so you need to call `awaitable_init` at least once per file. If you do not want to call `awaitable_init`
 outside of the module init function source file (say you separate the module init stuff from all the other module code like type objects, user defined module functions, etc.) then define
-`AWAITABLE_ABI_EXTERN` before the `#include <awaitable.h>` line in each source file. Also in any source file other than the one that holds the module init code define `AWAITABLE_API_DECLARE` as well.
+`AWAITABLE_ABI_EXTERN` before the `#include <awaitable.h>` line in each source file. Also in any source file other than the one that holds the module init code define `AWAITABLE_ABI_DECLARE` as well.
 
 For example, in the module init source file it would look like:
 
@@ -27,7 +27,7 @@ And in every other source file needing to use the ABI it would look like:
 
 ```c
 #define AWAITABLE_ABI_EXTERN
-#define AWAITABLE_API_DECLARE
+#define AWAITABLE_ABI_DECLARE
 #include <awaitable.h>
 ```
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -14,7 +14,23 @@ After installing PyAwaitable, you need to initialize the ABI. This is done with 
 
 Note that the ABI is initialized *per file* by default, so you need to call `awaitable_init` at least once per file. If you do not want to call `awaitable_init`
 outside of the module init function source file (say you separate the module init stuff from all the other module code like type objects, user defined module functions, etc.) then define
-`AWAITABLE_ABI_EXTERN` before the `#include <awaitable.h>` line in each source file.
+`AWAITABLE_ABI_EXTERN` before the `#include <awaitable.h>` line in each source file. Also in any source file other than the one that holds the module init code define `AWAITABLE_API_DECLARE` as well.
+
+For example, in the module init source file it would look like:
+
+```c
+#define AWAITABLE_ABI_EXTERN
+#include <awaitable.h>
+```
+
+And in every other source file needing to use the ABI it would look like:
+
+```c
+#define AWAITABLE_ABI_EXTERN
+#define AWAITABLE_API_DECLARE
+#include <awaitable.h>
+```
+
 This will then store the capsule pointer as a global on the module so then it can be accessed in every source file at once. If you call `awaitable_init` after the ABI is initialized, it does nothing.
 
 For example, the ABI can be initialized in a `PyInit_*` function:

--- a/include/awaitable.h
+++ b/include/awaitable.h
@@ -27,18 +27,18 @@ typedef struct _awaitable_abi {
 } AwaitableABI;
 
 #ifndef AWAITABLE_ABI_EXTERN
-#define AWAITABLE_ABI_EXTERN static
+#define AWAITABLE_EXTERN static
 #else
-#define AWAITABLE_ABI_EXTERN extern
+#define AWAITABLE_EXTERN extern
 #endif
 
 #ifndef AWAITABLE_ABI_DECLARE
-AWAITABLE_ABI_EXTERN AwaitableABI *awaitable_abi = NULL;
+AWAITABLE_EXTERN AwaitableABI *awaitable_abi = NULL;
 #else
-AWAITABLE_ABI_EXTERN AwaitableABI *awaitable_abi;
+AWAITABLE_EXTERN AwaitableABI *awaitable_abi;
 #endif
 
-#undef AWAITABLE_ABI_EXTERN  // so users of this header file cannot use this macro.
+#undef AWAITABLE_EXTERN  // so users of this header file cannot use this macro.
 
 // PyObject *awaitable_new(void);
 #define awaitable_new awaitable_abi->awaitable_new

--- a/include/awaitable.h
+++ b/include/awaitable.h
@@ -27,10 +27,18 @@ typedef struct _awaitable_abi {
 } AwaitableABI;
 
 #ifndef AWAITABLE_ABI_EXTERN
-static AwaitableABI *awaitable_abi = NULL;
+#define AWAITABLE_ABI_EXTERN static
 #else
-extern AwaitableABI *awaitable_abi = NULL;
+#define AWAITABLE_ABI_EXTERN extern
 #endif
+
+#ifndef AWAITABLE_API_DECLARE
+AWAITABLE_ABI_EXTERN AwaitableABI *awaitable_abi = NULL;
+#else
+AWAITABLE_ABI_EXTERN AwaitableABI *awaitable_abi;
+#endif
+
+#undef AWAITABLE_ABI_EXTERN  // so users of this header file cannot use this macro.
 
 // PyObject *awaitable_new(void);
 #define awaitable_new awaitable_abi->awaitable_new

--- a/include/awaitable.h
+++ b/include/awaitable.h
@@ -32,7 +32,7 @@ typedef struct _awaitable_abi {
 #define AWAITABLE_ABI_EXTERN extern
 #endif
 
-#ifndef AWAITABLE_API_DECLARE
+#ifndef AWAITABLE_ABI_DECLARE
 AWAITABLE_ABI_EXTERN AwaitableABI *awaitable_abi = NULL;
 #else
 AWAITABLE_ABI_EXTERN AwaitableABI *awaitable_abi;

--- a/include/pyawaitable/util.h
+++ b/include/pyawaitable/util.h
@@ -6,44 +6,13 @@
 #include <stdbool.h>
 #include <pyawaitable/backport.h>
 
-/* inline helpers. */
-static inline void _SetAllListItems(PyObject *all_list, int count, ...) {
-  va_list valist;
-  va_start(valist, count);
-  for (int i = 0; i < count; i++) {
-    PyList_SET_ITEM(all_list, i,
-                    PyUnicode_FromString(va_arg(valist, const char *)));
-  }
-  va_end(valist);
-}
-
-static inline PyObject *_DecrefModuleAndReturnNULL(PyObject *m) {
-  Py_XDECREF(m);
-  return NULL;
-}
-
-static inline PyObject *
-_PyType_CreateInstance(PyTypeObject *type, PyObject *args, PyObject *kwargs) {
-  PyObject *instance = type->tp_new(type, Py_None, Py_None);
-  if (type->tp_init(instance, args, kwargs) != 0) {
-    PyErr_Print();
-    Py_XDECREF(instance);
-    return NULL;
-  }
-
-  return instance;
-}
-
-static inline PyObject *_PyObject_GetCallableMethod(PyObject *obj,
-                                                    const char *name) {
-  PyObject *method = PyObject_GetAttrString(obj, name);
-  if (!PyCallable_Check(method)) {
-    Py_XDECREF(method);
-    return NULL;
-  }
-
-  return method;
-}
+/* helpers. */
+void _SetAllListItems(PyObject *all_list, int count, ...);
+PyObject *_DecrefModuleAndReturnNULL(PyObject *m);
+PyObject *
+_PyType_CreateInstance(PyTypeObject *type, PyObject *args, PyObject *kwargs);
+PyObject *_PyObject_GetCallableMethod(PyObject *obj,
+                                      const char *name);
 
 /* defines needed in the module init function. If only they were in the Python.h
  * include file. */
@@ -91,6 +60,12 @@ static inline PyObject *_PyObject_GetCallableMethod(PyObject *obj,
 
 #define PyType_CreateInstance(type, typeobj, args, kwargs)                     \
   ((type *)_PyType_CreateInstance(typeobj, args, kwargs))
+/*
+ * Users of this function must decref this after
+ * they are done with the returned method object.
+ * Result can be NULL if the method object was not found in object
+ * "type".
+ */
 #define PyObject_GetCallableMethod(type, name)                                 \
   _PyObject_GetCallableMethod((PyObject *)type, name)
 #endif

--- a/src/_pyawaitable/util.c
+++ b/src/_pyawaitable/util.c
@@ -1,0 +1,42 @@
+/* *INDENT-OFF* */
+// This code follows PEP 7 and CPython ABI conventions
+
+#include <pyawaitable/util.h>
+
+void _SetAllListItems(PyObject *all_list, int count, ...) {
+  va_list valist;
+  va_start(valist, count);
+  for (int i = 0; i < count; i++) {
+    PyList_SET_ITEM(all_list, i,
+                    PyUnicode_FromString(va_arg(valist, const char *)));
+  }
+  va_end(valist);
+}
+
+PyObject *_DecrefModuleAndReturnNULL(PyObject *m) {
+  Py_XDECREF(m);
+  return NULL;
+}
+
+PyObject *
+_PyType_CreateInstance(PyTypeObject *type, PyObject *args, PyObject *kwargs) {
+  PyObject *instance = type->tp_new(type, Py_None, Py_None);
+  if (type->tp_init(instance, args, kwargs) != 0) {
+    PyErr_Print();
+    Py_XDECREF(instance);
+    return NULL;
+  }
+
+  return instance;
+}
+
+PyObject *_PyObject_GetCallableMethod(PyObject *obj,
+                                      const char *name) {
+  PyObject *method = PyObject_GetAttrString(obj, name);
+  if (!PyCallable_Check(method)) {
+    Py_XDECREF(method);
+    return NULL;
+  }
+
+  return method;
+}

--- a/src/_pyawaitable/values.c
+++ b/src/_pyawaitable/values.c
@@ -43,7 +43,7 @@ awaitable_save_impl(PyObject *awaitable, Py_ssize_t nargs, ...)
 
     va_list vargs;
     va_start(vargs, nargs);
-    int offset = aw->aw_values_size;
+    Py_ssize_t offset = aw->aw_values_size;
 
     if (aw->aw_values == NULL)
         aw->aw_values = PyMem_Calloc(
@@ -64,7 +64,7 @@ awaitable_save_impl(PyObject *awaitable, Py_ssize_t nargs, ...)
 
     aw->aw_values_size += nargs;
 
-    for (int i = offset; i < aw->aw_values_size; i++)
+    for (Py_ssize_t i = offset; i < aw->aw_values_size; i++)
         aw->aw_values[i] = Py_NewRef(va_arg(vargs, PyObject*));
 
     va_end(vargs);
@@ -110,7 +110,7 @@ awaitable_save_arb_impl(PyObject *awaitable, Py_ssize_t nargs, ...)
 
     va_list vargs;
     va_start(vargs, nargs);
-    int offset = aw->aw_arb_values_size;
+    Py_ssize_t offset = aw->aw_arb_values_size;
 
     if (aw->aw_arb_values == NULL)
         aw->aw_arb_values = PyMem_Calloc(
@@ -131,7 +131,7 @@ awaitable_save_arb_impl(PyObject *awaitable, Py_ssize_t nargs, ...)
 
     aw->aw_arb_values_size += nargs;
 
-    for (int i = offset; i < aw->aw_arb_values_size; i++)
+    for (Py_ssize_t i = offset; i < aw->aw_arb_values_size; i++)
         aw->aw_arb_values[i] = va_arg(vargs, void *);
 
     va_end(vargs);


### PR DESCRIPTION
1. Fixed where linking in the ABI would fail if AWAITABLE_ABI_EXTERN is defined for using it in multiple different c source files while only init of the abi in the module init code only.
2. To make debugging of the ABI itself easier I moved the inline helpers to just normal helper functions that are defined in a new c source file. This would help when building debug builds of pyawaitable.
3. Changed a few ``Py_ssize_t`` > ``int`` downcasts that can result in loss of data when building for 64 bit python installs. The fix is to instead use ``Py_ssize_t`` in this code as well so it automatically adjusts to whatever Python.h defines it as.