### PR TITLE
Bump the leak limit from 10 KB to 50 KB.

### DIFF
--- a/tests/test_awaitable.py
+++ b/tests/test_awaitable.py
@@ -7,7 +7,7 @@ from collections.abc import Coroutine
 from pyawaitable.bindings import abi, add_await, awaitcallback, awaitcallback_err
 from conftest import limit_leaks
 
-LEAK_LIMIT: str = "10 KB"
+LEAK_LIMIT: str = "50 KB"
 
 raising_callback = ctypes.cast(_pyawaitable_test.raising_callback, awaitcallback)
 raising_err_callback = ctypes.cast(


### PR DESCRIPTION
Tests were failing at times with just a little bit over in "leaks" (caching and whatnot).