### PR TITLE
Rebranding and classifier fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyAwaitable
 
-## CPython API for asynchronous functions
+## Call asynchronous code from an extension module
 
 ![Tests](https://github.com/ZeroIntensity/pyawaitable/actions/workflows/tests.yml/badge.svg)
 ![Memory Check](https://github.com/ZeroIntensity/pyawaitable/actions/workflows/memory_check.yml/badge.svg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 license = { file = "LICENSE" }
 classifiers = [
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 dependencies = []

--- a/src/pyawaitable/__init__.py
+++ b/src/pyawaitable/__init__.py
@@ -1,5 +1,5 @@
 """
-PyAwaitable - CPython API for asynchronous functions.
+PyAwaitable - Call asynchronous code from an extension module.
 
 Docs: https://awaitable.zintensity.dev/
 Source: https://github.com/ZeroIntensity/pyawaitable


### PR DESCRIPTION
Rebrand to the description "Call asynchronous code from an extension module," and add the 3.13 classifier (and removed 3.8).