### PR TITLE
CI: Don't run unrelated workflows

### DIFF
--- a/.github/workflows/memory_check.yml
+++ b/.github/workflows/memory_check.yml
@@ -5,14 +5,14 @@ on:
         branches:
             - master
         paths:
-            - 'src/'
-            - '.github/workflows'
+            - 'src/**'
+            - '.github/workflows/memory_check.yml'
     pull_request:
         branches:
             - master
         paths:
-            - 'src/'
-            - '.github/workflows'
+            - 'src/**'
+            - '.github/workflows/memory_check.yml'
 
 env:
     PYTHONUNBUFFERED: "1"

--- a/.github/workflows/memory_check.yml
+++ b/.github/workflows/memory_check.yml
@@ -4,9 +4,15 @@ on:
     push:
         branches:
             - master
+        paths:
+            - 'src/'
+            - '.github/workflows'
     pull_request:
         branches:
             - master
+        paths:
+            - 'src/'
+            - '.github/workflows'
 
 env:
     PYTHONUNBUFFERED: "1"

--- a/.github/workflows/memory_leak.yml
+++ b/.github/workflows/memory_leak.yml
@@ -1,4 +1,4 @@
-name: Memory Check
+name: Memory Leaks
 
 on:
     push:
@@ -6,13 +6,13 @@ on:
             - master
         paths:
             - 'src/**'
-            - '.github/workflows/memory_check.yml'
+            - '.github/workflows/memory_leak.yml'
     pull_request:
         branches:
             - master
         paths:
             - 'src/**'
-            - '.github/workflows/memory_check.yml'
+            - '.github/workflows/memory_leak.yml'
 
 env:
     PYTHONUNBUFFERED: "1"
@@ -20,7 +20,7 @@ env:
     PYTHONIOENCODING: "utf8"
 
 jobs:
-    run:
+    memory-leaks:
         name: Check for memory leaks and errors
         runs-on: ubuntu-latest
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ env:
     PYTHONIOENCODING: "utf8"
 
 jobs:
-    run:
+    run-tests:
         name: Python ${{ matrix.python-version }} on ${{ startsWith(matrix.os, 'macos-') && 'macOS' || startsWith(matrix.os, 'windows-') && 'Windows' || 'Linux' }}
         runs-on: ${{ matrix.os }}
         strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,16 +5,16 @@ on:
         branches:
             - master
         paths:
-            - 'tests/'
-            - 'src/'
-            - '.github/workflows'
+            - 'tests/**'
+            - 'src/**'
+            - '.github/workflows/tests.yml'
     pull_request:
         branches:
             - master
         paths:
-            - 'tests/'
-            - 'src/'
-            - '.github/workflows'
+            - 'tests/**'
+            - 'src/**'
+            - '.github/workflows/tests.yml'
 
 concurrency:
     group: test-${{ github.head_ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,17 @@ on:
     push:
         branches:
             - master
+        paths:
+            - 'tests/'
+            - 'src/'
+            - '.github/workflows'
     pull_request:
         branches:
             - master
+        paths:
+            - 'tests/'
+            - 'src/'
+            - '.github/workflows'
 
 concurrency:
     group: test-${{ github.head_ref }}


### PR DESCRIPTION
- Add `paths` to the workflows to prevent them from being run for no reason.
- Rename `Memory Check` to `Memory Leaks`.
- Give job names something more specific so I can use them in status checks.