### PR TITLE
README: Fix 'Memory Leaks' badge (round two).

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Wheels](https://github.com/ZeroIntensity/pyawaitable/actions/workflows/build.yml/badge.svg)](https://github.com/ZeroIntensity/pyawaitable/actions/workflows/build.yml)
 ![Tests](https://github.com/ZeroIntensity/pyawaitable/actions/workflows/tests.yml/badge.svg)
-![Memory Leaks](https://github.com/ZeroIntensity/pyawaitable/actions/workflows/memory_leaks.yml/badge.svg)
+![Memory Leak](https://github.com/ZeroIntensity/pyawaitable/actions/workflows/memory_leak.yml/badge.svg)
 
 -   [Docs](https://awaitable.zintensity.dev)
 -   [Source](https://github.com/ZeroIntensity/pyawaitable)


### PR DESCRIPTION
Apparently, it's `memory_leak`, and not `memory_leaks`. 