### PR TITLE
CI: Setup an 'all checks pass' workflow.

### DIFF
--- a/.github/workflows/all_checks_pass.yml
+++ b/.github/workflows/all_checks_pass.yml
@@ -1,0 +1,9 @@
+name: All checks pass
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
+jobs:
+  allchecks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wechuli/allcheckspassed@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
             - v*
         branches:
             - master
+        paths:
+            - 'src/**'
 
 concurrency:
     group: build-${{ github.head_ref }}
@@ -45,7 +47,6 @@ jobs:
     binary-wheels-arm:
         name: Build Linux wheels for ARM
         runs-on: ubuntu-latest
-        # Very slow, no need to run on PRs
         if: >
             github.event_name == 'push'
             &&
@@ -63,7 +64,7 @@ jobs:
                   platforms: arm64
 
             - name: Build wheels
-              uses: pypa/cibuildwheel@v2.21.3
+              uses: pypa/cibuildwheel@v2.22.0
               env:
                   CIBW_ARCHS_LINUX: aarch64
                   HATCH_BUILD_HOOKS_ENABLE: "true"


### PR DESCRIPTION
* Add an 'All checks pass' workflow, because apparently GitHub doesn't report status checks if a job is skipped via `paths`
* Only run the build step on modifications to `src/`
* Bump CIBW to 2.22.0