### PR TITLE
Make pyawaitable.h support precompiled headers.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -191,6 +191,25 @@ The complete mapping of names to their Python API counterparts are:
 | `pyawaitable_abi`            | `PyAwaitable_ABI`             |
 | `PyAwaitableType`            | `PyAwaitable_Type`            |
 
+## Using Precompiled Headers with PyAwaitable
+
+Using precompiled headers in a large C extension project is supported, just replace `PYAWAITABLE_THIS_FILE_INIT` with `PYAWAITABLE_USE_PCH` ***BEFORE*** including your precompiled header file in every source file.
+
+After that in each non-module init C file this should be done ***AFTER*** including your precompiled header file:
+
+```c
+DECLARE_PYAWAITABLE_ABI;
+```
+
+And in the source file with the module initialization code:
+
+```c
+DECLARE_PYAWAITABLE_ABI = NULL;
+PYAWAITABLE_INIT_DEF;
+```
+
+After that all logic from the example code from `test.c` still applies.
+
 ## Vendored Copies
 
 PyAwaitable ships a vendorable version of each release, containing both a `pyawaitable.c` and `pyawaitable.h` file. For many users, it's much easier to vendor PyAwaitable than use it off PyPI. You can download the zip file containing a vendorable version [from the releases page](https://github.com/ZeroIntensity/pyawaitable/releases).

--- a/include/pyawaitable/with.h
+++ b/include/pyawaitable/with.h
@@ -2,7 +2,7 @@
 #define PYAWAITABLE_WITH_H
 
 #include <Python.h> // PyObject
-#include <pyawaitable//awaitableobject.h> // awaitcallback, awaitcallback_err
+#include <pyawaitable/awaitableobject.h> // awaitcallback, awaitcallback_err
 
 int
 pyawaitable_async_with_impl(

--- a/src/pyawaitable/pyawaitable.h
+++ b/src/pyawaitable/pyawaitable.h
@@ -54,10 +54,24 @@ typedef struct _pyawaitable_abi
     );
 } PyAwaitableABI;
 
+#ifdef PYAWAITABLE_USE_PCH
+/*
+ * Applications using Precompiled Headers must use this
+ * define to declare the abi pointer before using
+ * pyawaitable at all in any file.
+ * For the main file of a C that contains the module
+ * initialization code it is the user's responsibility
+ * to set this to null right after using the macro, but
+ * before they terminate the current line of code.
+ */
+#define DECLARE_PYAWAITABLE_ABI \
+extern PyAwaitableABI *pyawaitable_abi
+#else
 #ifdef PYAWAITABLE_THIS_FILE_INIT
 PyAwaitableABI *pyawaitable_abi = NULL;
 #else
 extern PyAwaitableABI *pyawaitable_abi;
+#endif
 #endif
 
 #define pyawaitable_new pyawaitable_abi->new
@@ -87,6 +101,22 @@ extern PyAwaitableABI *pyawaitable_abi;
 #define PyAwaitableType pyawaitable_abi->PyAwaitableType
 
 
+#ifdef PYAWAITABLE_USE_PCH
+#define PYAWAITABLE_INIT_DEF \
+static int \
+pyawaitable_init() \
+{ \
+    if (pyawaitable_abi != NULL) \
+        return 0; \
+\
+    PyAwaitableABI *capsule = PyCapsule_Import("_pyawaitable.abi_v1", 0); \
+    if (capsule == NULL) \
+        return -1; \
+\
+    pyawaitable_abi = capsule; \
+    return 0; \
+}
+#else
 #ifdef PYAWAITABLE_THIS_FILE_INIT
 static int
 pyawaitable_init()
@@ -113,6 +143,7 @@ pyawaitable_init()
     return -1;
 }
 
+#endif
 #endif
 
 #ifdef PYAWAITABLE_PYAPI


### PR DESCRIPTION
This change makes it possible to have pyawaitable included inside of a precompiled header. Precompiled headers can sometimes make large C extensions compile faster so this change could benefit some users.