### PR TITLE
CI: Fix platform compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
         branches:
             - master
         paths:
-            - '.github/workflows/memory_leak.yml'
+            - '.github/workflows/build.yml'
 
 concurrency:
     group: build-${{ github.head_ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,7 @@ concurrency:
     cancel-in-progress: true
 
 env:
-    CIBW_SKIP: >
-        pp*
+    CIBW_BUILD: cp3{9,10,11,12,13}-*
     PYAWAITABLE_OPTIMIZED: 1
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,11 @@ on:
             - master
         paths:
             - 'src/**'
+    pull_request:
+        branches:
+            - master
+        paths:
+            - '.github/workflows/memory_leak.yml'
 
 concurrency:
     group: build-${{ github.head_ref }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 ]
 dependencies = []
 dynamic = ["version"]
+requires-python = ">=3.9"
 
 [project.urls]
 Documentation = "https://awaitable.zintensity.dev"

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,11 @@ from glob import glob
 from setuptools import Extension, setup
 import os
 
+DEBUG_SYMBOLS = "/DEBUG" if os.name == "nt" else "-g"
+_OPTIMIZED = "/O3" if os.name == "nt" else "-O3"
+_NO_OPTIMIZATION = "" if os.name == "nt" else "-O0"
+OPTIMIZATION = _OPTIMIZED if os.environ.get("PYAWAITABLE_OPTIMIZED") else _NO_OPTIMIZATION
+
 if __name__ == "__main__":
     setup(
         name="pyawaitable",
@@ -13,7 +18,7 @@ if __name__ == "__main__":
                 "_pyawaitable",
                 glob("./src/_pyawaitable/*.c"),
                 include_dirs=["./include/", "./src/pyawaitable/"],
-                extra_compile_args=["-g", "-O3" if os.environ.get("PYAWAITABLE_OPTIMIZED") else "-O0"],
+                extra_compile_args=[DEBUG_SYMBOLS, OPTIMIZATION],
             )
         ],
         package_dir={"": "src"},

--- a/src/_pyawaitable/coro.c
+++ b/src/_pyawaitable/coro.c
@@ -53,16 +53,13 @@ awaitable_throw(PyObject *self, PyObject *args)
     PyObject *traceback = NULL;
 
     if (!PyArg_ParseTuple(args, "O|OO", &type, &value, &traceback))
+    {
         return NULL;
+    }
 
     if (PyType_Check(type))
     {
-        PyObject *err = PyObject_Vectorcall(
-            type,
-            (PyObject *[]){value},
-            1,
-            NULL
-        );
+        PyObject *err = PyObject_CallOneArg(type, value);
         if (err == NULL)
         {
             return NULL;
@@ -107,7 +104,8 @@ awaitable_throw(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    Py_UNREACHABLE();
+    assert(PyErr_Occurred());
+    return NULL;
 }
 
 #if PY_MINOR_VERSION > 9


### PR DESCRIPTION
Apparently, #48 broke some builds.

- Fixes compiler flags used on Windows.
- Removes usage of `Py_UNREACHABLE`, which apparently only works on Linux.