### PR TITLE
CI: Fix missing pytest installation in the memory errors workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,13 @@ jobs:
       - name: Set up Python 3.12
         uses: actions/setup-python@v2
         with:
-          python-version: 3.12            
+          python-version: 3.12
+
+      - name: Install Pytest
+        run: |
+            pip install pytest pytest-asyncio pytest-memray typing_extensions
+        shell: bash
+
       - name: Build PyAwaitable
         run: pip install .
 


### PR DESCRIPTION
Apparently, I forgot to do that.