### PR TITLE
CI: Roll back actions/upload-artifact to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
 
         steps:
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@v3
               with:
                   name: artifacts
                   path: dist


### PR DESCRIPTION
For whatever reason, v4 breaks the upload job now. See https://github.com/actions/upload-artifact/issues/478. I'm just going to roll it back for the time being and retry the 1.4.0 release.