### PR TITLE
CI/Workflow: Use Hatch for the test suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,6 @@ env:
   PYTHONUNBUFFERED: "1"
   FORCE_COLOR: "1"
   PYTHONIOENCODING: "utf8"
-  PYAWAITABLE_OPTIMIZED: 1
 
 jobs:
   changes:
@@ -45,21 +44,18 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Build PyAwaitable
-        run: pip install . --verbose
-
-      - name: Build PyAwaitable Test Package
-        run: pip install ./tests --verbose
+      
+      - name: Install Hatch
+        uses: pypa/hatch@install
 
       - name: Run tests
-        run: python -W error -m unittest tests/main.py --verbose
+        run: hatch test
 
   tests-pass:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,6 @@ To build PyAwaitable locally, simple run `pip`:
 $ pip install .
 ```
 
-It's highly recommended to do this inside of a [virtual environment](https://docs.python.org/3/library/venv.html).
-
 ## Running Tests
 
 PyAwaitable uses [Hatch](https://hatch.pypa.io), so that will handle everything for you:

--- a/hatch.toml
+++ b/hatch.toml
@@ -19,3 +19,10 @@ os.environ['PYAWAITABLE_INCLUDE'] = pyawaitable.include(suppress_error=True)
 [build.hooks.custom]
 enable-by-default = true
 dependencies = ["typing_extensions"]
+
+[envs.hatch-test]
+dependencies = ["pyawaitable_test @ {root:uri}/tests", "pytest"]
+default-args = ["--verbose"]
+
+[[envs.hatch-test.matrix]]
+python = ["3.13", "3.12", "3.11", "3.10", "3.9"]


### PR DESCRIPTION
- Allows the test suite to be run via `hatch test`.
- Switches us back over to `pytest` from `unittest`, so we can use `pytest-memray` again soon.