### PR TITLE
Tests: Add new tests for callbacks

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -8,7 +8,7 @@ from typing import Callable, TextIO, TypeVar
 
 try:
     from typing import ParamSpec
-except ImportError as err:
+except ImportError:
     # Let's hope it's installed!
     from typing_extensions import ParamSpec
 import re
@@ -58,9 +58,13 @@ NO_EXPLICIT_REGEX = re.compile(r".*_PyAwaitable_NO_MANGLE\((.+)\).*")
 DEFINE_REGEX = re.compile(r" *# *define *(\w+)(\(.*\))?.*")
 
 HEADER_GUARD = """
-#if !defined(PYAWAITABLE_VENDOR_H) && !defined(Py_LIMITED_API)
+#ifndef PYAWAITABLE_VENDOR_H
 #define PYAWAITABLE_VENDOR_H
 #define _PYAWAITABLE_VENDOR
+
+#ifdef Py_LIMITED_API
+#error "Sorry, the limited API cannot be used with PyAwaitable."
+#endif
 """
 HEADER = (
     lambda version: f"""\
@@ -394,9 +398,7 @@ def main(version: str) -> None:
             process_files(f)
             write(
                 f,
-                """#else
-#error "the limited API cannot be used with pyawaitable"
-#endif /* PYAWAITABLE_VENDOR_H */""",
+                "#endif /* PYAWAITABLE_VENDOR_H */",
             )
 
     log(f"Created PyAwaitable distribution at {dist}")

--- a/src/_pyawaitable/awaitable.c
+++ b/src/_pyawaitable/awaitable.c
@@ -138,6 +138,7 @@ PyAwaitable_AddAwait(
 )
 {
     PyAwaitableObject *aw = (PyAwaitableObject *) self;
+    assert(Py_IS_TYPE(Py_TYPE(self), PyAwaitable_GetType()));
     if (coro == NULL) {
         PyErr_SetString(
             PyExc_ValueError,
@@ -190,6 +191,7 @@ _PyAwaitable_API(int)
 PyAwaitable_DeferAwait(PyObject * awaitable, PyAwaitable_Defer cb)
 {
     PyAwaitableObject *aw = (PyAwaitableObject *) awaitable;
+    assert(Py_IS_TYPE(Py_TYPE(awaitable), PyAwaitable_GetType()));
     pyawaitable_callback *aw_c = PyMem_Malloc(sizeof(pyawaitable_callback));
     if (aw_c == NULL) {
         PyErr_NoMemory();
@@ -214,6 +216,7 @@ _PyAwaitable_API(int)
 PyAwaitable_SetResult(PyObject * awaitable, PyObject * result)
 {
     PyAwaitableObject *aw = (PyAwaitableObject *) awaitable;
+    assert(Py_IS_TYPE(Py_TYPE(awaitable), PyAwaitable_GetType()));
     aw->aw_result = Py_NewRef(result);
     return 0;
 }

--- a/src/_pyawaitable/genwrapper.c
+++ b/src/_pyawaitable/genwrapper.c
@@ -213,6 +213,7 @@ get_awaitable_iterator(PyObject *op)
         )
     ) {
         // Fall back to the dunder
+        // XXX Is this case possible?
         PyObject *__await__ = PyObject_GetAttrString(op, "__await__");
         if (__await__ == NULL) {
             return NULL;

--- a/src/_pyawaitable/with.c
+++ b/src/_pyawaitable/with.c
@@ -31,7 +31,7 @@ async_with_inner(PyObject *aw, PyObject *res)
         if (tp == NULL) {
             PyErr_SetString(
                 PyExc_SystemError,
-                "pyawaitable: async with callback returned -1 without exception set"
+                "PyAwaitable: `async with` callback returned -1 without exception set"
             );
             return -1;
         }
@@ -94,7 +94,7 @@ PyAwaitable_AsyncWith(
     if (with == NULL) {
         PyErr_Format(
             PyExc_TypeError,
-            "pyawaitable: %R is not an async context manager (missing __aenter__)",
+            "PyAwaitable: %R is not an async context manager (missing __aenter__)",
             ctx
         );
         return -1;
@@ -104,7 +104,7 @@ PyAwaitable_AsyncWith(
         Py_DECREF(with);
         PyErr_Format(
             PyExc_TypeError,
-            "pyawaitable: %R is not an async context manager (missing __aexit__)",
+            "PyAwaitable: %R is not an async context manager (missing __aexit__)",
             ctx
         );
         return -1;

--- a/tests/module.c
+++ b/tests/module.c
@@ -13,6 +13,7 @@ _pyawaitable_test_exec(PyObject *mod)
         } while (0)
 
     ADD_TESTS(awaitable);
+    ADD_TESTS(callbacks);
 #undef ADD_TESTS
     return PyAwaitable_Init();
 }

--- a/tests/pyawaitable_test.h
+++ b/tests/pyawaitable_test.h
@@ -5,5 +5,6 @@
 #include "test_util.h"
 
 extern TESTS(awaitable);
+extern TESTS(callbacks);
 
 #endif

--- a/tests/test_awaitable.c
+++ b/tests/test_awaitable.c
@@ -91,7 +91,7 @@ test_add_await(PyObject *self, PyObject *coro)
 }
 
 static PyObject *
-test_add_await_no_memory(PyObject *self, PyObject *coro)
+test_add_await_special_cases(PyObject *self, PyObject *coro)
 {
     PyObject *awaitable = PyAwaitable_New();
     if (awaitable == NULL) {
@@ -153,16 +153,7 @@ static PyObject *
 coroutine_trampoline(PyObject *self, PyObject *coro)
 {
     TEST_ASSERT(Py_IS_TYPE(coro, &PyCoro_Type));
-    PyObject *awaitable = PyAwaitable_New();
-    if (awaitable == NULL) {
-        return NULL;
-    }
-
-    if (PyAwaitable_AddAwait(awaitable, coro, NULL, NULL) < 0) {
-        Py_DECREF(awaitable);
-        return NULL;
-    }
-
+    PyObject *awaitable = Test_NewAwaitableWithCoro(coro, NULL, NULL);
     return awaitable;
 }
 
@@ -171,7 +162,7 @@ TESTS(awaitable) = {
     TEST(test_awaitable_new),
     TEST(test_set_result),
     TEST_CORO(test_add_await),
-    TEST_CORO(test_add_await_no_memory),
+    TEST_CORO(test_add_await_special_cases),
     TEST_UTIL(coroutine_trampoline),
     {NULL}
 };

--- a/tests/test_awaitable.c
+++ b/tests/test_awaitable.c
@@ -158,7 +158,7 @@ coroutine_trampoline(PyObject *self, PyObject *coro)
         return NULL;
     }
 
-    if (PyAwaitable_AddAwait(coro, awaitable, NULL, NULL) < 0) {
+    if (PyAwaitable_AddAwait(awaitable, coro, NULL, NULL) < 0) {
         Py_DECREF(awaitable);
         return NULL;
     }

--- a/tests/test_awaitable.c
+++ b/tests/test_awaitable.c
@@ -149,11 +149,29 @@ test_add_await_no_memory(PyObject *self, PyObject *coro)
     return Test_RunAwaitable(awaitable);
 }
 
+static PyObject *
+coroutine_trampoline(PyObject *self, PyObject *coro)
+{
+    TEST_ASSERT(Py_IS_TYPE(coro, &PyCoro_Type));
+    PyObject *awaitable = PyAwaitable_New();
+    if (awaitable == NULL) {
+        return NULL;
+    }
+
+    if (PyAwaitable_AddAwait(coro, awaitable, NULL, NULL) < 0) {
+        Py_DECREF(awaitable);
+        return NULL;
+    }
+
+    return awaitable;
+}
+
 TESTS(awaitable) = {
     TEST_UTIL(generic_awaitable),
     TEST(test_awaitable_new),
     TEST(test_set_result),
     TEST_CORO(test_add_await),
     TEST_CORO(test_add_await_no_memory),
+    TEST_UTIL(coroutine_trampoline),
     {NULL}
 };

--- a/tests/test_callbacks.c
+++ b/tests/test_callbacks.c
@@ -1,31 +1,190 @@
 #include <Python.h>
 #include <pyawaitable.h>
 #include "pyawaitable_test.h"
+#include "pyerrors.h"
+
+static int _Thread_local callback_called = 0;
+static int _Thread_local error_callback_called = 0;
 
 static int
 simple_callback(PyObject *awaitable, PyObject *value)
 {
+    TEST_ASSERT_INT(awaitable != NULL);
     TEST_ASSERT_INT(value == Py_None);
+    TEST_ASSERT_INT(Py_IS_TYPE(Py_TYPE(awaitable), PyAwaitable_GetType()));
+    TEST_ASSERT_INT(callback_called == 0);
+    callback_called = 1;
     return 0;
 }
 
-static PyObject *
-test_simple_callback(PyObject *self, PyObject *coro)
+static int
+aborting_callback(PyObject *awaitable, PyObject *value)
 {
-    PyObject *awaitable = PyAwaitable_New();
+    Py_FatalError("Test case shouldn't have ever reached here!");
+}
+
+static int
+error_callback(PyObject *awaitable, PyObject *err)
+{
+    TEST_ASSERT_INT(!PyErr_Occurred());
+    TEST_ASSERT_INT(awaitable != NULL);
+    TEST_ASSERT_INT(Py_IS_TYPE(Py_TYPE(awaitable), PyAwaitable_GetType()));
+    TEST_ASSERT_INT(err != NULL);
+    TEST_ASSERT_INT(
+        Py_IS_TYPE(
+            Py_TYPE(err),
+            (PyTypeObject *)PyExc_ZeroDivisionError
+        )
+    );
+    TEST_ASSERT_INT(error_callback_called == 0);
+    error_callback_called = 1;
+    return 0;
+}
+
+static int
+repropagating_error_callback(PyObject *awaitable, PyObject *err)
+{
+    TEST_ASSERT_INT(!PyErr_Occurred());
+    TEST_ASSERT_INT(awaitable != NULL);
+    TEST_ASSERT_INT(Py_IS_TYPE(Py_TYPE(awaitable), PyAwaitable_GetType()));
+    TEST_ASSERT_INT(err != NULL);
+    TEST_ASSERT_INT(
+        Py_IS_TYPE(
+            Py_TYPE(err),
+            (PyTypeObject *)PyExc_ZeroDivisionError
+        )
+    );
+    TEST_ASSERT_INT(error_callback_called == 0);
+    error_callback_called = 1;
+    return -1;
+}
+
+static int
+overwriting_error_callback(PyObject *awaitable, PyObject *err)
+{
+    TEST_ASSERT_INT(!PyErr_Occurred());
+    TEST_ASSERT_INT(awaitable != NULL);
+    TEST_ASSERT_INT(Py_IS_TYPE(Py_TYPE(awaitable), PyAwaitable_GetType()));
+    TEST_ASSERT_INT(err != NULL);
+    TEST_ASSERT_INT(
+        Py_IS_TYPE(
+            Py_TYPE(err),
+            (PyTypeObject *)PyExc_ZeroDivisionError
+        )
+    );
+    TEST_ASSERT_INT(error_callback_called == 0);
+    error_callback_called = 1;
+    // Some random exception that probably won't occur elsewhere
+    PyErr_SetNone(PyExc_FileExistsError);
+    return -2;
+}
+
+static PyObject *
+test_callback_is_called(PyObject *self, PyObject *coro)
+{
+    callback_called = 0;
+    PyObject *awaitable = Test_NewAwaitableWithCoro(
+        coro,
+        simple_callback,
+        NULL
+    );
     if (awaitable == NULL) {
         return NULL;
     }
+    Py_DECREF(Test_RunAwaitable(awaitable));
+    TEST_ASSERT(callback_called == 1);
+    Py_RETURN_NONE;
+}
 
-    if (PyAwaitable_AddAwait(awaitable, coro, simple_callback, NULL) < 0) {
-        Py_DECREF(awaitable);
+static PyObject *
+test_callback_not_invoked_when_exception(PyObject *self, PyObject *coro)
+{
+    PyObject *awaitable = Test_NewAwaitableWithCoro(
+        coro,
+        aborting_callback,
+        NULL
+    );
+    if (awaitable == NULL) {
         return NULL;
     }
+    Py_DECREF(Test_RunAwaitable(awaitable));
+    EXPECT_ERROR(PyExc_ZeroDivisionError);
+    Py_RETURN_NONE;
+}
 
-    return Test_RunAwaitable(awaitable);
+static PyObject *
+test_error_callback_not_invoked_when_ok(PyObject *self, PyObject *coro)
+{
+    callback_called = 0;
+    PyObject *awaitable = Test_NewAwaitableWithCoro(
+        coro,
+        simple_callback,
+        aborting_callback
+    );
+    if (awaitable == NULL) {
+        return NULL;
+    }
+    Py_DECREF(Test_RunAwaitable(awaitable /* stolen */));
+    TEST_ASSERT(callback_called == 1);
+    Py_RETURN_NONE;
+}
+
+static PyObject *
+test_error_callback_gets_exception_from_coro(PyObject *self, PyObject *coro)
+{
+    error_callback_called = 0;
+    PyObject *awaitable = Test_NewAwaitableWithCoro(
+        coro,
+        aborting_callback,
+        error_callback
+    );
+    Py_DECREF(Test_RunAwaitable(awaitable));
+    TEST_ASSERT(error_callback_called == 1);
+    Py_RETURN_NONE;
+}
+
+static PyObject *
+test_failing_error_callback_repropagates_exception(
+    PyObject *self,
+    PyObject *coro
+)
+{
+    error_callback_called = 0;
+    PyObject *awaitable = Test_NewAwaitableWithCoro(
+        coro,
+        aborting_callback,
+        repropagating_error_callback
+    );
+    Py_DECREF(Test_RunAwaitable(awaitable));
+    EXPECT_ERROR(PyExc_ZeroDivisionError);
+    TEST_ASSERT(error_callback_called == 1);
+    Py_RETURN_NONE;
+}
+
+static PyObject *
+test_error_callback_can_overwrite_exception(
+    PyObject *self,
+    PyObject *coro
+)
+{
+    error_callback_called = 0;
+    PyObject *awaitable = Test_NewAwaitableWithCoro(
+        coro,
+        aborting_callback,
+        overwriting_error_callback
+    );
+    Py_DECREF(Test_RunAwaitable(awaitable));
+    EXPECT_ERROR(PyExc_FileExistsError);
+    TEST_ASSERT(error_callback_called == 1);
+    Py_RETURN_NONE;
 }
 
 TESTS(callbacks) = {
-    TEST_CORO(test_simple_callback),
+    TEST_CORO(test_callback_is_called),
+    TEST_RAISING_CORO(test_callback_not_invoked_when_exception),
+    TEST_CORO(test_error_callback_not_invoked_when_ok),
+    TEST_RAISING_CORO(test_error_callback_gets_exception_from_coro),
+    TEST_RAISING_CORO(test_failing_error_callback_repropagates_exception),
+    TEST_RAISING_CORO(test_error_callback_can_overwrite_exception),
     {NULL}
 };

--- a/tests/test_callbacks.c
+++ b/tests/test_callbacks.c
@@ -1,0 +1,7 @@
+#include <Python.h>
+#include <pyawaitable.h>
+#include "pyawaitable_test.h"
+
+TESTS(callbacks) = {
+    {NULL}
+};

--- a/tests/test_callbacks.c
+++ b/tests/test_callbacks.c
@@ -3,8 +3,8 @@
 #include "pyawaitable_test.h"
 #include "pyerrors.h"
 
-static int _Thread_local callback_called = 0;
-static int _Thread_local error_callback_called = 0;
+static int PyAwaitable_thread_local callback_called = 0;
+static int PyAwaitable_thread_local error_callback_called = 0;
 
 static int
 simple_callback(PyObject *awaitable, PyObject *value)

--- a/tests/test_callbacks.c
+++ b/tests/test_callbacks.c
@@ -2,6 +2,30 @@
 #include <pyawaitable.h>
 #include "pyawaitable_test.h"
 
+static int
+simple_callback(PyObject *awaitable, PyObject *value)
+{
+    TEST_ASSERT_INT(value == Py_None);
+    return 0;
+}
+
+static PyObject *
+test_simple_callback(PyObject *self, PyObject *coro)
+{
+    PyObject *awaitable = PyAwaitable_New();
+    if (awaitable == NULL) {
+        return NULL;
+    }
+
+    if (PyAwaitable_AddAwait(awaitable, coro, simple_callback, NULL) < 0) {
+        Py_DECREF(awaitable);
+        return NULL;
+    }
+
+    return Test_RunAwaitable(awaitable);
+}
+
 TESTS(callbacks) = {
+    TEST_CORO(test_simple_callback),
     {NULL}
 };

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,7 +3,7 @@ import asyncio
 from typing import Any, Callable
 from collections.abc import Awaitable, Coroutine
 import inspect
-from pytest import warns
+from pytest import raises, warns
 
 NOT_FOUND = """
 The PyAwaitable test package wasn't built!
@@ -23,6 +23,17 @@ def test_awaitable_semantics():
 
     with warns(ResourceWarning):
         del awaitable
+    
+async def raising_coroutine():
+    await asyncio.sleep(0)
+    raise ZeroDivisionError()
+
+
+def test_coroutine_propagates_exception():
+    awaitable = _pyawaitable_test.coroutine_trampoline(raising_coroutine())
+    with raises(ZeroDivisionError):
+        asyncio.run(awaitable)
+
 
 def coro_wrap_call(method: Callable[[Awaitable[Any]], Any]) -> Callable[[], None]:
     def wrapper(*_: Any):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,3 @@
-import unittest
 import asyncio
 from typing import Any, Callable
 from collections.abc import Awaitable, Coroutine
@@ -59,6 +58,3 @@ for method in dir(_pyawaitable_test):
         def _wrapped(testfunc: Callable[..., Any]) -> Any:
             return lambda: testfunc()
         globals()[method] = _wrapped(case)
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_util.h
+++ b/tests/test_util.h
@@ -2,10 +2,12 @@
 #define PYAWAITABLE_TEST_UTIL_H
 
 #include <Python.h>
+#include <pyawaitable.h>
 
 #define TEST(name) {#name, name, METH_NOARGS, NULL}
 #define TEST_UTIL(name) {#name, name, METH_O, NULL}
 #define TEST_CORO(name) {#name "_needs_coro", name, METH_O, NULL}
+#define TEST_RAISING_CORO(name) {#name "_needs_rcoro", name, METH_O, NULL}
 #define TEST_ERROR(msg)           \
         PyErr_Format(             \
     PyExc_AssertionError,         \
@@ -64,5 +66,12 @@ _Test_RunAndCheck(
     __FILE__,                    \
     __LINE__                     \
         );
+
+PyObject *
+Test_NewAwaitableWithCoro(
+    PyObject *coro,
+    PyAwaitable_Callback callback,
+    PyAwaitable_Error error
+);
 
 #endif

--- a/tests/test_util.h
+++ b/tests/test_util.h
@@ -13,7 +13,7 @@
     __func__,                     \
     __LINE__                      \
         );
-#define TEST_ASSERT(cond)                               \
+#define TEST_ASSERT_RETVAL(cond, retval)                \
         do {                                            \
             if (!(cond)) {                              \
                 PyErr_Format(                           \
@@ -22,9 +22,11 @@
     __func__,                                           \
     __LINE__                                            \
                 );                                      \
-                return NULL;                            \
+                return retval;                          \
             }                                           \
         } while (0)
+#define TEST_ASSERT(cond) TEST_ASSERT_RETVAL(cond, NULL)
+#define TEST_ASSERT_INT(cond) TEST_ASSERT_RETVAL(cond, -1)
 #define TESTS(name) PyMethodDef _pyawaitable_test_ ## name []
 #define EXPECT_ERROR(tp)                                    \
         do {                                                \

--- a/tests/util.c
+++ b/tests/util.c
@@ -116,11 +116,10 @@ _Test_RunAndCheck(
 )
 {
     PyObject *res = Test_RunAwaitable(awaitable);
+    Py_DECREF(awaitable);
     if (res == NULL) {
-        Py_DECREF(awaitable);
         return NULL;
     }
-    Py_DECREF(awaitable);
     if (res != expected) {
         PyErr_Format(
             PyExc_AssertionError,

--- a/tests/util.c
+++ b/tests/util.c
@@ -136,3 +136,23 @@ _Test_RunAndCheck(
     Py_DECREF(res);
     Py_RETURN_NONE;
 }
+
+PyObject *
+Test_NewAwaitableWithCoro(
+    PyObject *coro,
+    PyAwaitable_Callback callback,
+    PyAwaitable_Error error
+)
+{
+    PyObject *awaitable = PyAwaitable_New();
+    if (awaitable == NULL) {
+        return NULL;
+    }
+
+    if (PyAwaitable_AddAwait(awaitable, coro, callback, error) < 0) {
+        Py_DECREF(awaitable);
+        return NULL;
+    }
+
+    return awaitable;
+}


### PR DESCRIPTION
This also fixed a bug where error callbacks could be called with `NULL` if the user callback returned -1 without an exception set.

Also does a little bit of unrelated refactoring because I'm too lazy to create a bunch of PRs:

- Formalize the error messages in the `async with` implementation (primarily `pyawaitable` -> `PyAwaitable`)
- Remove old unittest artifacts in `test_main`.
- Add a couple of extra tests for awaitable semantics.