### PR TITLE
Tests: Add new tests for the value APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Breaking Change:** Renamed `awaitcallback` to `PyAwaitable_Callback`
 - **Breaking Change:** Renamed `awaitcallback_err` to `PyAwaitable_Error`
 - **Breaking Change:** Renamed `defercallback` to `PyAwaitable_Defer`
+- **Breaking Change:** Removed the integer value APIs (`SaveIntValues`, `LoadIntValues`, `SetIntValue`, `GetIntValue`). They proved to be maintenance heavy, unintuitive, and most of all replaceable with the arbitrary values API (via `malloc`ing an integer and storing it).
 
 ## [1.4.0] - 2025-02-09
 

--- a/include/pyawaitable/values.h
+++ b/include/pyawaitable/values.h
@@ -53,29 +53,4 @@ PyAwaitable_GetArbValue(
     Py_ssize_t index
 );
 
-/* Integer values */
-
-_PyAwaitable_API(int)
-PyAwaitable_SaveIntValues(
-    PyObject * awaitable,
-    Py_ssize_t nargs,
-    ...
-);
-
-_PyAwaitable_API(int)
-PyAwaitable_UnpackIntValues(PyObject * awaitable, ...);
-
-_PyAwaitable_API(int)
-PyAwaitable_SetIntValue(
-    PyObject * awaitable,
-    Py_ssize_t index,
-    long new_value
-);
-
-_PyAwaitable_API(long)
-PyAwaitable_GetIntValue(
-    PyObject * awaitable,
-    Py_ssize_t index
-);
-
 #endif

--- a/src/_pyawaitable/values.c
+++ b/src/_pyawaitable/values.c
@@ -153,36 +153,3 @@ PyAwaitable_GetArbValue(
 {
     GET(aw_arbitrary_values, void *);
 }
-
-/* Integer Values */
-
-_PyAwaitable_API(int)
-PyAwaitable_UnpackIntValues(PyObject * awaitable, ...)
-{
-    UNPACK(aw_integer_values, long);
-}
-
-_PyAwaitable_API(int)
-PyAwaitable_SaveIntValues(PyObject * awaitable, Py_ssize_t nargs, ...)
-{
-    SAVE(aw_integer_values, long, NOTHING);
-}
-
-_PyAwaitable_API(int)
-PyAwaitable_SetIntValue(
-    PyObject * awaitable,
-    Py_ssize_t index,
-    long new_value
-)
-{
-    SET(aw_integer_values, long);
-}
-
-_PyAwaitable_API(long)
-PyAwaitable_GetIntValue(
-    PyObject * awaitable,
-    Py_ssize_t index
-)
-{
-    GET(aw_integer_values, long);
-}

--- a/tests/module.c
+++ b/tests/module.c
@@ -14,6 +14,7 @@ _pyawaitable_test_exec(PyObject *mod)
 
     ADD_TESTS(awaitable);
     ADD_TESTS(callbacks);
+    ADD_TESTS(values);
 #undef ADD_TESTS
     return PyAwaitable_Init();
 }

--- a/tests/pyawaitable_test.h
+++ b/tests/pyawaitable_test.h
@@ -6,5 +6,6 @@
 
 extern TESTS(awaitable);
 extern TESTS(callbacks);
+extern TESTS(values);
 
 #endif

--- a/tests/test_callbacks.c
+++ b/tests/test_callbacks.c
@@ -1,7 +1,6 @@
 #include <Python.h>
 #include <pyawaitable.h>
 #include "pyawaitable_test.h"
-#include "pyerrors.h"
 
 static int PyAwaitable_thread_local callback_called = 0;
 static int PyAwaitable_thread_local error_callback_called = 0;

--- a/tests/test_values.c
+++ b/tests/test_values.c
@@ -219,5 +219,6 @@ TESTS(values) = {
     TEST(test_store_and_load_arbitrary_values),
     TEST(test_load_fails_when_no_values),
     TEST(test_load_null_pointer),
+    TEST(test_get_and_set_values),
     {NULL}
 };

--- a/tests/test_values.c
+++ b/tests/test_values.c
@@ -1,0 +1,98 @@
+#include <Python.h>
+#include <pyawaitable.h>
+#include "pyawaitable_test.h"
+
+static PyObject *
+test_store_and_load_object_values(PyObject *self, PyObject *nothing)
+{
+    PyObject *awaitable = PyAwaitable_New();
+    if (awaitable == NULL) {
+        return NULL;
+    }
+
+    PyObject *num = PyLong_FromLong(999);
+    if (num == NULL) {
+        Py_DECREF(awaitable);
+        return NULL;
+    }
+
+    PyObject *str = PyUnicode_FromString("hello");
+    if (str == NULL) {
+        Py_DECREF(awaitable);
+        Py_DECREF(num);
+        return NULL;
+    }
+
+    int fail = PyAwaitable_UnpackValues(awaitable);
+    EXPECT_ERROR(PyExc_RuntimeError);
+    TEST_ASSERT(fail == -1);
+
+    if (PyAwaitable_SaveValues(awaitable, 2, num, str) < 0) {
+        Py_DECREF(awaitable);
+        Py_DECREF(num);
+        Py_DECREF(str);
+        return NULL;
+    }
+    Py_DECREF(num);
+    Py_DECREF(str);
+    TEST_ASSERT(Py_REFCNT(num) >= 1);
+    TEST_ASSERT(Py_REFCNT(str) >= 1);
+
+    PyObject *num_unpacked;
+    PyObject *str_unpacked;
+
+    if (
+        PyAwaitable_UnpackValues(
+            awaitable,
+            &num_unpacked,
+            &str_unpacked
+        ) < 0
+    ) {
+        Py_DECREF(awaitable);
+        return NULL;
+    }
+
+    TEST_ASSERT(num_unpacked == num);
+    TEST_ASSERT(str_unpacked == str);
+    PyAwaitable_Cancel(awaitable);
+    Py_RETURN_NONE;
+}
+
+static PyObject *
+test_object_values_can_outlive_awaitable(PyObject *self, PyObject *nothing)
+{
+    PyObject *awaitable = PyAwaitable_New();
+    if (awaitable == NULL) {
+        return NULL;
+    }
+
+    PyObject *dummy =
+        PyUnicode_FromString("nobody expects the spanish inquisition");
+    if (dummy == NULL) {
+        Py_DECREF(awaitable);
+        return NULL;
+    }
+
+    if (PyAwaitable_SaveValues(awaitable, 1, dummy) < 0) {
+        Py_DECREF(awaitable);
+        Py_DECREF(dummy);
+        return NULL;
+    }
+
+    PyAwaitable_Cancel(awaitable);
+    Py_DECREF(awaitable);
+    assert(
+        PyUnicode_CompareWithASCIIString(
+            dummy,
+            "nobody expects the spanish inquisition"
+        )
+    );
+    Py_DECREF(dummy);
+    Py_RETURN_NONE;
+}
+
+TESTS(values) = {
+    TEST(test_store_and_load_object_values),
+    TEST(test_object_values_can_outlive_awaitable),
+    {NULL}
+};

--- a/tests/test_values.c
+++ b/tests/test_values.c
@@ -201,11 +201,11 @@ test_get_and_set_arbitrary_values(PyObject *self, PyObject *nothing)
 
     TEST_ASSERT(PyAwaitable_GetArbValue(awaitable, 1) == dummy);
 
-    void *fail = PyAwaitable_GetArbValue(awaitable, 4);
+    void *fail = PyAwaitable_GetArbValue(awaitable, 3);
     EXPECT_ERROR(PyExc_IndexError);
     TEST_ASSERT(fail == NULL);
 
-    int other_fail = PyAwaitable_SetArbValue(awaitable, 5, dummy);
+    int other_fail = PyAwaitable_SetArbValue(awaitable, 3, dummy);
     EXPECT_ERROR(PyExc_IndexError);
     TEST_ASSERT(other_fail < 0);
 
@@ -254,11 +254,11 @@ test_get_and_set_object_values(PyObject *self, PyObject *nothing)
     TEST_ASSERT(PyAwaitable_GetValue(awaitable, 1) == one);
     TEST_ASSERT(Py_REFCNT(one) >= 2);
 
-    PyObject *fail = PyAwaitable_GetValue(awaitable, 4);
+    PyObject *fail = PyAwaitable_GetValue(awaitable, 3);
     EXPECT_ERROR(PyExc_IndexError);
     TEST_ASSERT(fail == NULL);
 
-    int other_fail = PyAwaitable_SetValue(awaitable, 5, one);
+    int other_fail = PyAwaitable_SetValue(awaitable, 3, one);
     EXPECT_ERROR(PyExc_IndexError);
     TEST_ASSERT(other_fail < 0);
 


### PR DESCRIPTION
With this, I also decided to remove the integer value functions. They're a bit buggy because they only really work with longs, which doesn't cover enough use cases. I could add integer APIs for every single type of integer, but it's really not worth it compared to just allocating an integer and storing it via the arbitrary values.