### PR TITLE
Core: Add `PyAwaitable_AddExpr` for convenience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-Nothing yet!
+-   Added `PyAwaitable_AddExpr`.
 
 ## [2.0.1] - 2025-06-15
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -97,6 +97,23 @@ Coroutines
     set on failure.
 
 
+.. c:function:: int PyAwaitable_AddExpr(PyObject *awaitable, PyObject *expr, PyAwaitable_Callback result_callback, PyAwaitable_Error error_callback)
+
+   Similar to :c:func:`PyAwaitable_AddAwait`, but designed for convenience.
+
+   If *expr* is ``NULL``, this function returns ``-1`` without an exception
+   set. If *expr* is non-``NULL``, this function calls
+   :c:func:`PyAwaitable_AddAwait` with all the provided arguments, and then
+   steals a reference to *expr*.
+
+   This behavior allows you to use other C API functions directly with this
+   one. For example, if you had an ``async def`` function ``coro``, it could
+   be added to the PyAwaitable object with
+   ``PyAwaitable_AddExpr(awaitable, PyObject_CallNoArgs(coro), NULL, NULL)``.
+
+   .. versionadded:: 2.1
+   
+
 Value Storage
 -------------
 

--- a/docs/usage/value_storage.rst
+++ b/docs/usage/value_storage.rst
@@ -127,19 +127,12 @@ as such:
             return NULL;
         }
 
-        PyObject *coro = PyObject_CallNoArgs(get_number_io);
-        if (coro == NULL) {
+        if (PyAwaitable_AddExpr(awaitable, PyObject_CallNoArgs(get_number_io),
+                                multiply_callback, NULL) < 0) {
             Py_DECREF(awaitable);
             return NULL;
         }
 
-        if (PyAwaitable_AddAwait(awaitable, coro, multiply_callback, NULL) < 0) {
-            Py_DECREF(awaitable);
-            Py_DECREF(coro);
-            return NULL;
-        }
-
-        Py_DECREF(coro);
         return awaitable;
     }
 

--- a/src/_pyawaitable/awaitable.c
+++ b/src/_pyawaitable/awaitable.c
@@ -210,6 +210,24 @@ PyAwaitable_AddAwait(
 }
 
 _PyAwaitable_API(int)
+PyAwaitable_AddExpr(
+    PyObject * self,
+    PyObject * expr,
+    PyAwaitable_Callback cb,
+    PyAwaitable_Error err
+)
+{
+    assert(self != NULL);
+    if (expr == NULL) {
+        return -1;
+    }
+
+    int res = PyAwaitable_AddAwait(self, expr, cb, err);
+    Py_DECREF(expr);
+    return res;
+}
+
+_PyAwaitable_API(int)
 PyAwaitable_DeferAwait(PyObject * awaitable, PyAwaitable_Defer cb)
 {
     PyAwaitableObject *aw = (PyAwaitableObject *) awaitable;

--- a/tests/test_awaitable.c
+++ b/tests/test_awaitable.c
@@ -171,11 +171,6 @@ test_add_await_expr(PyObject *self, PyObject *nothing)
     res = PyAwaitable_AddExpr(awaitable, PyAwaitable_New(), NULL, NULL);
     TEST_ASSERT(res == 0);
 
-    Test_SetNoMemory();
-    res = PyAwaitable_AddExpr(awaitable, PyAwaitable_New(), NULL, NULL);
-    Test_UnSetNoMemory();
-    TEST_ASSERT(res == -1);
-
     PyAwaitable_Cancel(awaitable);
     Py_RETURN_NONE;
 }

--- a/tests/test_awaitable.c
+++ b/tests/test_awaitable.c
@@ -157,6 +157,29 @@ coroutine_trampoline(PyObject *self, PyObject *coro)
     return awaitable;
 }
 
+static PyObject *
+test_add_await_expr(PyObject *self, PyObject *nothing)
+{
+    PyObject *awaitable = PyAwaitable_New();
+    if (awaitable == NULL) {
+        return NULL;
+    }
+
+    int res = PyAwaitable_AddExpr(awaitable, NULL, NULL, NULL);
+    TEST_ASSERT(res == -1);
+
+    res = PyAwaitable_AddExpr(awaitable, PyAwaitable_New(), NULL, NULL);
+    TEST_ASSERT(res == 0);
+
+    Test_SetNoMemory();
+    res = PyAwaitable_AddExpr(awaitable, PyAwaitable_New(), NULL, NULL);
+    Test_UnSetNoMemory();
+    TEST_ASSERT(res == -1);
+
+    PyAwaitable_Cancel(awaitable);
+    Py_RETURN_NONE;
+}
+
 TESTS(awaitable) = {
     TEST_UTIL(generic_awaitable),
     TEST(test_awaitable_new),
@@ -164,5 +187,6 @@ TESTS(awaitable) = {
     TEST_CORO(test_add_await),
     TEST_CORO(test_add_await_special_cases),
     TEST_UTIL(coroutine_trampoline),
+    TEST(test_add_await_expr),
     {NULL}
 };


### PR DESCRIPTION
Inspired by `PyModule_Add`. This function is equivalent to `PyAwaitable_AddAwait`, but returns `NULL` without setting an exception when given a `NULL` coroutine, and steals a reference to the coroutine when it is non-`NULL`. This makes it possible to directly use C API functions in the single `PyAwaitable_AddExpr` call.